### PR TITLE
Dev/0.0.17 alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
     - `inserted`
     - `assign`
     - `assigned`
+    - `import`
+    - `imported`
+    - `extract`
+    - `extracted`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@
     - `loaded`
     - `do`
     - `perform`
+    - `save`
+    - `saved`
+    - `load`
+    - `loaded`
+    - `reload`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
 * Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively
 * Fixed `siemkit.send.tcp` function
 * Added `siemkit.event.Cef` aliases for `severity` & `deviceSeverity` are now both acceptable
-* Added `siemkit.parse.boolean` new valid values for `True`:
+* Created a `default` settings dictionary for the `siemkit.parse` library
+    - Included: `parse_true` key holding a set of words to parse as `True`
+* Added `siemkit.parse.boolean` (based on `default['parse_true']`) new valid values for `True`:
     - `active`
     - `activated`
     - `include`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@
     - `extract`
     - `extracted`
     - `+`
+    - `promote`
+    - `promoted`
+    - `acknowledge`
+    - `acknowledged`
+    - `affirmative`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Version 0.0.17-dev
-* Added random time generation `siemkit.random.time`
+* Added a random time generation `siemkit.random.time`
+* Added a random time delta generation `siemkit.random.timedelta`
+* Added a random time delta support for timedelta parsing `siemkit.parse.timedelta`
+    - e.g. `from every 2 minutes and 30 seconds to 5 minutes` is now supported.
 * Re-imported sub-libraries for multi-layered APIs
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
     - `extract`
     - `extracted`
     - `+`
+    - `v`
+    - `x`
     - `promote`
     - `promoted`
     - `acknowledge`
@@ -83,6 +85,8 @@
     - `affirmative`
     - `happy`
     - `positive`
+    - `select`
+    - `selected`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - `between 2 days ago and now`
         - `between 3 days ago and 2 days ago`
         - `between 1/1/2020 and 31/12/2023`
+* Added parsing support for time range: `siemkit.parse.time_range` will produce a tuple of start and end time
 * Re-imported sub-libraries for multi-layered APIs
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
     - `imported`
     - `extract`
     - `extracted`
+    - `+`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 0.0.17-dev
+* Added random time generation `siemkit.random.time`
+
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener
     - `siemkit.listen.udp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 * Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively
 * Fixed `siemkit.send.tcp` function
 * Added `siemkit.event.Cef` aliases for `severity` & `deviceSeverity` are now both acceptable
+* Added `siemkit.parse.boolean` new valid values for `True`:
+    - `active`
+    - `activated`
+    - `include`
+    - `included`
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - `Esm.add_activelist_entries()`
 * Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
     - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
+* Improved ArcSight ESM API `retrieve_event_ids` generator to be able to filter event types and retrieve recursively.
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 * Added parsing support for time range: `siemkit.parse.time_range` will produce a tuple of start and end time
 * Re-imported sub-libraries for multi-layered APIs
 * All generators under `siemkit.random` were refactored from `compose` to `generate`
+* Added ESM API Manager methods:
+    - `Esm.get_activelist_fields()`,
+    - `Esm.get_activelist.columns()`,
+    - `Esm.add_activelist.entries()`
+* Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
+    - Not proving `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@
     - `acknowledge`
     - `acknowledged`
     - `affirmative`
+    - `happy`
+    - `positive`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@
     - `positive`
     - `select`
     - `selected`
+    - `matter`
+    - `important`
+    - `done`
+    - `load`
+    - `loaded`
+    - `do`
+    - `perform`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 * Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively
 * Fixed `siemkit.send.tcp` function
 * Added `siemkit.event.Cef` aliases for `severity` & `deviceSeverity` are now both acceptable
+* Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
+    - Also supports `bool` value type as argument
 * Created a `default` settings dictionary for the `siemkit.parse` library
     - Included: `parse_true` key holding a set of words to parse as `True`
 * Added `siemkit.parse.boolean` (based on `default['parse_true']`) new valid values for `True`:
@@ -104,9 +106,6 @@
     - `loaded`
     - `reload`
     - `get`
-
-* Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
-    - Also supports `bool` value type as argument
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
     - `load`
     - `loaded`
     - `reload`
-    - `*`
+
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
     - Also supports `bool` value type as argument
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 * Re-imported sub-libraries for multi-layered APIs
 * All generators under `siemkit.random` were refactored from `compose` to `generate`
 * Added ArcSight ESM API Manager methods:
-    - `Esm.get_activelist_fields()`,
-    - `Esm.get_activelist_columns()`,
+    - `Esm.get_activelist_fields()`
+    - `Esm.get_activelist_columns()`
     - `Esm.add_activelist_entries()`
 * Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
     - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
     - `contained`
     - `insert`
     - `inserted`
+    - `assign`
+    - `assigned`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
         - `between yesterday and now`
         - `between 2 days ago and now`
         - `between 3 days ago and 2 days ago`
-        - `between 1/1/2020 to 31/12/2023`
+        - `between 1/1/2020 and 31/12/2023`
 * Re-imported sub-libraries for multi-layered APIs
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@
     - `Esm.get_activelist_fields()`
     - `Esm.get_activelist_columns()`
     - `Esm.add_activelist_entries()`
-* Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
-    - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
-* Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively.
+* Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional
+    - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call
+* Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively
 * Fixed `siemkit.send.tcp` function
+* Added `siemkit.event.Cef` aliases for `severity` & `deviceSeverity` are now both acceptable
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - `between 1/1/2020 and 31/12/2023`
 * Added parsing support for time range: `siemkit.parse.time_range` will produce a tuple of start and end time
 * Re-imported sub-libraries for multi-layered APIs
+* All generators under `siemkit.random` were refactored from `compose` to `generate`
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
     - `load`
     - `loaded`
     - `reload`
+    - `*`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
     - Also supports `bool` value type as argument
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@
     - `load`
     - `loaded`
     - `reload`
-* Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
+* Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
+    - Also supports `bool` value type as argument
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Added parsing support for time range: `siemkit.parse.time_range` will produce a tuple of start and end time
 * Re-imported sub-libraries for multi-layered APIs
 * All generators under `siemkit.random` were refactored from `compose` to `generate`
-* Added ESM API Manager methods:
+* Added ArcSight ESM API Manager methods:
     - `Esm.get_activelist_fields()`,
     - `Esm.get_activelist.columns()`,
     - `Esm.add_activelist.entries()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
     - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
 * Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively.
+* Fixed `siemkit.send.tcp` function
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 * All generators under `siemkit.random` were refactored from `compose` to `generate`
 * Added ArcSight ESM API Manager methods:
     - `Esm.get_activelist_fields()`,
-    - `Esm.get_activelist.columns()`,
-    - `Esm.add_activelist.entries()`
+    - `Esm.get_activelist_columns()`,
+    - `Esm.add_activelist_entries()`
 * Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
     - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
     - `load`
     - `loaded`
     - `reload`
+    - `get`
 
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
     - Also supports `bool` value type as argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
     - `alive`
     - `live`
     - `lives`
+    - `contain`
+    - `contained`
+    - `insert`
+    - `inserted`
 * Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
     - `+`
     - `v`
     - `x`
+    - `y`
     - `promote`
     - `promoted`
     - `acknowledge`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
     - `Esm.get_activelist.columns()`,
     - `Esm.add_activelist.entries()`
 * Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
-    - Not proving `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
+    - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 * Added a random time generation `siemkit.random.time`
 * Added a random time delta generation `siemkit.random.timedelta`
 * Added a random time delta support for timedelta parsing `siemkit.parse.timedelta`
-    - e.g. `from every 2 minutes and 30 seconds to 5 minutes` is now supported.
+    - Examples of supported strings:
+     - `from 1 day to 2 days`
+     - `from 5 minutes to 1 hour`
+     - `from every 2 minutes and 30 seconds to 5 minutes` 
+* Added a random time support for time parsing `siemkit.parse.time`
+    - Examples of supported strings:
+     - `between yesterday and today`
+     - `between yesterday and now`
+     - `between 2 days ago and now`
+     - `between 3 days ago and 2 days ago`
+     - `between 1/1/2020 to 31/12/2023`
 * Re-imported sub-libraries for multi-layered APIs
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
     - `+`
     - `v`
     - `x`
+    - `k`
     - `y`
     - `promote`
     - `promoted`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@
 * Added a random time delta generation `siemkit.random.timedelta`
 * Added a random time delta support for timedelta parsing `siemkit.parse.timedelta`
     - Examples of supported strings:
-     - `from 1 day to 2 days`
-     - `from 5 minutes to 1 hour`
-     - `from every 2 minutes and 30 seconds to 5 minutes` 
+        - `from 1 day to 2 days`
+        - `from 5 minutes to 1 hour`
+        - `from every 2 minutes and 30 seconds to 5 minutes` 
 * Added a random time support for time parsing `siemkit.parse.time`
     - Examples of supported strings:
-     - `between yesterday and today`
-     - `between yesterday and now`
-     - `between 2 days ago and now`
-     - `between 3 days ago and 2 days ago`
-     - `between 1/1/2020 to 31/12/2023`
+        - `between yesterday and today`
+        - `between yesterday and now`
+        - `between 2 days ago and now`
+        - `between 3 days ago and 2 days ago`
+        - `between 1/1/2020 to 31/12/2023`
 * Re-imported sub-libraries for multi-layered APIs
 
 ## Version 0.0.16-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
     - `Esm.add_activelist_entries()`
 * Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional.
     - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call.
-* Improved ArcSight ESM API `retrieve_event_ids` generator to be able to filter event types and retrieve recursively.
+* Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively.
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Version 0.0.17-dev
 * Added random time generation `siemkit.random.time`
+* Re-imported sub-libraries for multi-layered APIs
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,42 @@
     - `activated`
     - `include`
     - `included`
+    - `enable`
+    - `enabled`
+    - `set`
+    - `ready`
+    - `allow`
+    - `allowed`
+    - `process`
+    - `processed`
+    - `add`
+    - `added`
+    - `run`
+    - `running`
+    - `go`
+    - `start`
+    - `able`
+    - `capable`
+    - `possible`
+    - `can`
+    - `permit`
+    - `permitted`
+    - `show`
+    - `create`
+    - `created`
+    - `awake`
+    - `wake`
+    - `wakeup`
+    - `wake-up`
+    - `wake up`
+    - `power`
+    - `power-up`
+    - `powerup`
+    - `power up`
+    - `alive`
+    - `live`
+    - `lives`
+* Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`.
 
 ## Version 0.0.16-dev
 * Implemented prototype UDP listener

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pytimeparse~=1.1.8
 dateparser~=0.7.6
 future~=0.18.2
 requests~=2.24.0
-setuptools~=49.3.2
+setuptools~=50.0.0
 urllib3~=1.25.10

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setup(
     name='siemkit',
     # version='0.0.15a1.dev1',
-    version='0.0.16',
+    version='0.0.17',
     packages=['siemkit', 'hfilesize'] + find_packages(),
     include_package_data=True,
     url='https://github.com/cybersiem',

--- a/siemkit/api/__init__.py
+++ b/siemkit/api/__init__.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from . import arcsight
+
 """
 An accessible API database.
 """

--- a/siemkit/api/arcsight/__init__.py
+++ b/siemkit/api/arcsight/__init__.py
@@ -11,3 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from . import esm
+

--- a/siemkit/api/arcsight/esm/__init__.py
+++ b/siemkit/api/arcsight/esm/__init__.py
@@ -17,6 +17,8 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Tuple
 
+from . import v72
+
 
 class ArcSightUri(ABC):
 

--- a/siemkit/api/arcsight/esm/v72/activelist.py
+++ b/siemkit/api/arcsight/esm/v72/activelist.py
@@ -51,13 +51,14 @@ class AddEntries(ArcSightUri):
         entry_columns = []
         entry_list = []
 
+        # Build JSON
         for entry in entries:
             for column in columns:
                 entry_columns.append(entry[column])
 
             entry_list.append(
                 {
-                    'entry': entry_columns
+                    'entry': list(entry_columns)
                 }
             )
 
@@ -177,7 +178,7 @@ class FindByUuid(ArcSightUri):
 
     def args(self, variables) -> Tuple[str, dict]:
         return (
-            '/www/manager-service/rest/ArchiveReportService/findByUUID',
+            '/www/manager-service/rest/ActiveListService/findByUUID',
             {
                 'headers': {
                     'Content-Type': 'application/json',
@@ -185,9 +186,9 @@ class FindByUuid(ArcSightUri):
                 },
                 'method': 'POST',
                 'json': {
-                        "arc.findByUUID": {
-                            "arc.authToken": variables.get('token', ''),
-                            "arc.id": variables.get("uuid", '')
+                        "act.findByUUID": {
+                            "act.authToken": variables.get('token', ''),
+                            "act.id": variables.get("uuid", '')
                         }
                 }
             }
@@ -220,3 +221,4 @@ class ActiveListApiEnum(ArcSightUriEnum):
     DELETE_ENTRIES = DeleteEntries()
     CLEAR_ENTRIES = ClearEntries()
     FIND_ALL_IDS = FindAllIds()
+    FIND_BY_UUID = FindByUuid()

--- a/siemkit/arcsight/__init__.py
+++ b/siemkit/arcsight/__init__.py
@@ -207,7 +207,7 @@ class Esm:
             aggregated=True,
             base=True,
             action=True,
-            recurse=False,
+            sub_events=False,
             events_cache=None,
             deduplicate=True,
             limit=-1,
@@ -294,7 +294,7 @@ class Esm:
                     yield event
                     limit -= 1
 
-                if recurse:
+                if sub_events:
                     base_event_ids = event.get('baseEventIds')
                     if base_event_ids:
                         yield from self.retrieve_event_ids(
@@ -305,7 +305,7 @@ class Esm:
                             aggregated=aggregated,
                             base=base,
                             action=action,
-                            recurse=recurse,
+                            sub_events=sub_events,
                             events_cache=events_cache,
                             deduplicate=deduplicate,
                             limit=limit,

--- a/siemkit/arcsight/__init__.py
+++ b/siemkit/arcsight/__init__.py
@@ -35,6 +35,8 @@ http_request_module = RequestsModule(requests)
 urllib3.disable_warnings()
 
 
+# ToDo: Separate event ID generator from getter(?)
+# ToDo: If correlation event, yield base_events(?)
 class Esm:
 
     def __init__(

--- a/siemkit/arcsight/__init__.py
+++ b/siemkit/arcsight/__init__.py
@@ -216,12 +216,12 @@ class Esm:
         if events_cache is None:
             events_cache = {}
 
-        # ToDo: If deduplication is enabled, skip already cached IDs
-        # ToDo: If event is already cached, do not request, just yield from cache.
-        # ToDo: The remaining should be added to a single future re-request (recursive mode)
-        # ToDo: Cache newly retrieved events (recursive mode)
-        # ToDo: Yield event if its type allowed.
-        # ToDo: Recurse on event IDs from base (if recurse==True).
+        # Done: If deduplication is enabled, skip already cached IDs
+        # Done: If event is already cached, do not request, just yield from cache.
+        # Done: The remaining should be added to a single future re-request (recursive mode)
+        # Done: Cache newly retrieved events (recursive mode)
+        # Done: Yield event if its type allowed.
+        # Done: Recurse on event IDs from base (if recurse==True).
 
         def unpack_ids(event_ids_):
             for event_id_ in event_ids_:
@@ -243,12 +243,12 @@ class Esm:
                 if event_id_ in events_cache:
                     yield event_id_
 
-        unpacked_event_ids = unpack_ids(event_ids)
+        unpacked_event_ids = list(unpack_ids(event_ids))
         if deduplicate:
             # Only new event IDs -- For recursive use
             event_ids = new_event_ids(unpacked_event_ids)
         else:
-            event_ids = list(unpacked_event_ids)
+            event_ids = unpacked_event_ids
 
         retrieve_types = set()
 
@@ -273,7 +273,7 @@ class Esm:
 
         # New events to retrieve
         retrieve_event_ids = list(new_event_ids(event_ids))
-        input(f"Cache: {events_cache.keys()} | To Retrieve: {retrieve_event_ids}")
+        # input(f"Cache: {events_cache.keys()} | To Retrieve: {retrieve_event_ids}")
 
         for event in self._retrieve_event_ids(
                 retrieve_event_ids,
@@ -287,12 +287,12 @@ class Esm:
             if event_id in events_cache:
                 if deduplicate:
                     continue
-
             events_cache[event_id] = event  # Store in cache
 
             if event_type is not None:
                 if event_type in retrieve_types:
-                    print(f"Current level {level} | Event ID: {event_id} | Cache: {events_cache.keys()} | To Retrieve: {retrieve_event_ids}")
+                    # print(f"Current level {level} | Event ID: {event_id} | Cache: {events_cache.keys()}
+                    # | To Retrieve: {retrieve_event_ids}")
                     yield event
 
                 if recurse:
@@ -311,24 +311,6 @@ class Esm:
                             deduplicate=deduplicate,
                             level=level + 1
                         )
-                        # for inner_event in self.retrieve_event_ids(
-                        #     base_event_ids,
-                        #     start_millis=start_millis,
-                        #     end_millis=end_millis,
-                        #     correlation=correlation,
-                        #     aggregated=aggregated,
-                        #     base=base,
-                        #     action=action,
-                        #     recurse=recurse,
-                        #     events_cache=events_cache,
-                        #     deduplicate=deduplicate
-                        # ):
-                        #     # if deduplicate and event_id in events_cache:
-                        #     #     pass
-                        #     # else:
-                        #     #     yield inner_event
-                        #     print(inner_event['eventId'])
-                        #     yield inner_event
 
     def base_events(self, correlation_event, events_cache=None):
 

--- a/siemkit/arcsight/__init__.py
+++ b/siemkit/arcsight/__init__.py
@@ -204,8 +204,7 @@ class Esm:
             base_events_list = correlation_event.get('baseEventIds')
 
             if base_events_list is not None:
-                for event in self.retrieve_event_ids(base_events_list):
-                    yield event
+                yield from self.retrieve_event_ids(base_events_list)
 
     def get_activelist_attributes(self, resource_id):
         variables = {

--- a/siemkit/arcsight/__init__.py
+++ b/siemkit/arcsight/__init__.py
@@ -157,7 +157,10 @@ class Esm:
 
         return response
 
-    def get_event_ids(self, *event_ids, start_millis='-1', end_millis='-1'):
+    # def get_event_ids(self, *event_ids, start_millis='-1', end_millis='-1'):
+    #     return list(self.retrieve_event_ids(*event_ids, start_millis=start_millis, end_millis=end_millis))
+
+    def retrieve_event_ids(self, *event_ids, start_millis='-1', end_millis='-1'):
 
         def extract_ids():
             for event_id in event_ids:
@@ -194,6 +197,15 @@ class Esm:
             raise Exception(f"Event IDs '{' ,'.join((str(event_id) for event_id in event_ids))}' were not found.")
 
         return simplified_cef_events(response)
+
+    def base_events(self, correlation_event):
+
+        if isinstance(correlation_event, dict):
+            base_events_list = correlation_event.get('baseEventIds')
+
+            if base_events_list is not None:
+                for event in self.retrieve_event_ids(base_events_list):
+                    yield event
 
     def get_activelist_attributes(self, resource_id):
         variables = {

--- a/siemkit/data.py
+++ b/siemkit/data.py
@@ -25,6 +25,8 @@ from siemkit.file import open
 from siemkit import adaptors
 from siemkit.hash import crc32_file
 
+# ToDo: Create a dict class with context manager states control like our CommonEvent class
+
 
 class FileTracker:
 

--- a/siemkit/event.py
+++ b/siemkit/event.py
@@ -723,6 +723,7 @@ class Cef(EventFormat):
         'destinationGeoLongitude': 'dlong',
         'sourceGeoLatitude': 'slat',
         'sourceGeoLongitude': 'slong',
+        'severity': 'deviceSeverity'
     }
 
     __default_keys = siemkit_data.words_set(__default_aliases)

--- a/siemkit/ldap.py
+++ b/siemkit/ldap.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+# ToDo: Verify this: https://blackhattutorial.com/what-is-ldap-injection-and-how-to-prevent-it/
+
 from enum import IntFlag
 from enum import Enum
 from typing import Generator

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,7 +151,7 @@ def boolean(bool_string: Union[str, bool]) -> bool:
 
     bool_string = bool_string.strip().lower()
     return bool_string in {
-        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'some', 'active', 'activated', 'include', 'included',
+        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', 'some', 'active', 'activated', 'include', 'included',
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,8 +151,8 @@ def boolean(bool_string: Union[str, bool]) -> bool:
 
     bool_string = bool_string.strip().lower()
     return bool_string in {
-        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', 'some', 'active', 'activated', 'include', 'included',
-        'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
+        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', '*', 'some', 'active', 'activated', 'include',
+        'included', 'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -152,7 +152,8 @@ def boolean(bool_string: str) -> bool:
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
-        'import', 'imported', 'extract', 'extracted'
+        'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
+        'affirmative'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -146,7 +146,13 @@ def size(size_string: str) -> int:
 def boolean(bool_string: str) -> bool:
 
     bool_string = bool_string.strip().lower()
-    return bool_string in ('t', 'true', 'yes', 'ok', 'on', '1', 'some', 'active', 'activated', 'include', 'included')
+    return bool_string in {
+        't', 'true', 'yes', 'ok', 'on', '1', 'some', 'active', 'activated', 'include', 'included',
+        'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
+        'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
+        'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
+        'power up', 'alive', 'live', 'lives'
+    }
 
 
 def variable(var_string: str, var_dict: dict) -> Any:

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -153,7 +153,7 @@ def boolean(bool_string: str) -> bool:
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
         'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
-        'affirmative'
+        'affirmative', 'happy', 'positive'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -37,6 +37,20 @@ import dateparser
 #     license: https://github.com/scrapinghub/dateparser/blob/master/LICENSE
 
 
+default = {
+    'parse_true': {
+        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', 'some', 'active', 'activated', 'include',
+        'included', 'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
+        'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
+        'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
+        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
+        'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
+        'affirmative', 'happy', 'positive', 'select', 'selected', 'matter', 'important', 'done', 'load', 'loaded',
+        'do', 'perform', 'save', 'saved', 'load', 'loaded', 'reload', 'get'
+    }
+}
+
+
 def time_range(time_string: str) -> Tuple[datetime.datetime, datetime.datetime]:
     assigned_range = re.match(r'^.*?between\s(.*?)\sand\s(.*?$)', time_string, flags=re.IGNORECASE)
     if assigned_range:
@@ -150,16 +164,7 @@ def boolean(bool_string: Union[str, bool]) -> bool:
         return bool_string
 
     bool_string = bool_string.strip().lower()
-    return bool_string in {
-        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', 'some', 'active', 'activated', 'include',
-        'included', 'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
-        'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
-        'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
-        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
-        'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
-        'affirmative', 'happy', 'positive', 'select', 'selected', 'matter', 'important', 'done', 'load', 'loaded',
-        'do', 'perform', 'save', 'saved', 'load', 'loaded', 'reload', 'get'
-    }
+    return bool_string in default['parse_true']
 
 
 def variable(var_string: str, var_dict: dict) -> Any:

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -146,7 +146,7 @@ def size(size_string: str) -> int:
 def boolean(bool_string: str) -> bool:
 
     bool_string = bool_string.strip().lower()
-    return bool_string in ('t', 'true', 'yes', 'ok', 'on', '1', 'some', 'active', 'activated')
+    return bool_string in ('t', 'true', 'yes', 'ok', 'on', '1', 'some', 'active', 'activated', 'include', 'included')
 
 
 def variable(var_string: str, var_dict: dict) -> Any:

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -158,7 +158,7 @@ def boolean(bool_string: Union[str, bool]) -> bool:
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
         'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
         'affirmative', 'happy', 'positive', 'select', 'selected', 'matter', 'important', 'done', 'load', 'loaded',
-        'do', 'perform', 'save', 'saved', 'load', 'loaded', 'reload'
+        'do', 'perform', 'save', 'saved', 'load', 'loaded', 'reload', 'get'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,7 +151,8 @@ def boolean(bool_string: str) -> bool:
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
-        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned'
+        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
+        'import', 'imported', 'extract', 'extracted'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -17,6 +17,8 @@ from collections import deque
 import datetime
 import re
 
+from siemkit import random
+
 import pytimeparse
 # * pytimeparse - MIT License
 #     by: wroberts
@@ -72,11 +74,30 @@ def timedelta(time_delta_string: str) -> datetime.timedelta:
         Results in:
          datetime.timedelta(days=15, seconds=45015)
 
+        Words like `every` and `and` are ignored.
+
+        A random timedelta can also be acquired using `from` and `to` words:
+            "from every 1 second to 2 minutes"
+
+        This will produce a random timedelta between `1 second` to `2 minutes`.
+
     :param time_delta_string:
     :return: timedelta object
     """
     time_delta_string = time_delta_string.lower().replace("and", '').replace('every', '')
-    return datetime.timedelta(seconds=pytimeparse.parse(time_delta_string))
+
+    assigned_range = re.match(r'^.*?from\s(.*?)\sto\s(.*?$)', time_delta_string)
+
+    if assigned_range:
+        from_time_string, to_time_string = assigned_range.groups()
+        result = random.timedelta(
+            datetime.timedelta(seconds=pytimeparse.parse(from_time_string)),
+            datetime.timedelta(seconds=pytimeparse.parse(to_time_string))
+        )
+    else:
+        result = datetime.timedelta(seconds=pytimeparse.parse(time_delta_string))
+
+    return result
 
 
 def size(size_string: str) -> int:

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,7 +151,7 @@ def boolean(bool_string: Union[str, bool]) -> bool:
 
     bool_string = bool_string.strip().lower()
     return bool_string in {
-        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', '*', 'some', 'active', 'activated', 'include',
+        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'k', 'some', 'active', 'activated', 'include',
         'included', 'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,7 +151,7 @@ def boolean(bool_string: str) -> bool:
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
-        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted'
+        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,7 +151,7 @@ def boolean(bool_string: str) -> bool:
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
-        'power up', 'alive', 'live', 'lives'
+        'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -146,7 +146,7 @@ def size(size_string: str) -> int:
 
 def boolean(bool_string: Union[str, bool]) -> bool:
 
-    if type(bool_string, bool):
+    if isinstance(bool_string, bool):
         return bool_string
 
     bool_string = bool_string.strip().lower()

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -14,6 +14,7 @@
 
 from typing import Any
 from typing import Tuple
+from typing import Union
 from collections import deque
 import datetime
 import re
@@ -143,7 +144,10 @@ def size(size_string: str) -> int:
     return hfilesize.FileSize(size_string)
 
 
-def boolean(bool_string: str) -> bool:
+def boolean(bool_string: Union[str, bool]) -> bool:
+
+    if type(bool_string, bool):
+        return bool_string
 
     bool_string = bool_string.strip().lower()
     return bool_string in {

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -147,7 +147,7 @@ def boolean(bool_string: str) -> bool:
 
     bool_string = bool_string.strip().lower()
     return bool_string in {
-        't', 'true', 'yes', 'ok', 'on', '1', 'some', 'active', 'activated', 'include', 'included',
+        't', 'true', 'yes', 'ok', 'on', '1', '+', 'some', 'active', 'activated', 'include', 'included',
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -59,7 +59,17 @@ def time(time_string: str) -> datetime.datetime:
     :param time_string:
     :return: datetime object
     """
-    return dateparser.parse(time_string)
+    assigned_range = re.match(r'^.*?between\s(.*?)\sand\s(.*?$)', time_string, flags=re.IGNORECASE)
+    if assigned_range:
+        from_time_string, to_time_string = assigned_range.groups()
+        result = random.time(
+            dateparser.parse(from_time_string),
+            dateparser.parse(to_time_string)
+        )
+    else:
+        result = dateparser.parse(time_string)
+
+    return result
 
 
 def timedelta(time_delta_string: str) -> datetime.timedelta:

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -151,7 +151,7 @@ def boolean(bool_string: Union[str, bool]) -> bool:
 
     bool_string = bool_string.strip().lower()
     return bool_string in {
-        't', 'true', 'yes', 'ok', 'on', '1', '+', 'v', 'x', 'some', 'active', 'activated', 'include', 'included',
+        't', 'true', 'yes', 'y', 'ok', 'on', '1', '+', 'v', 'x', 'some', 'active', 'activated', 'include', 'included',
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -147,13 +147,13 @@ def boolean(bool_string: str) -> bool:
 
     bool_string = bool_string.strip().lower()
     return bool_string in {
-        't', 'true', 'yes', 'ok', 'on', '1', '+', 'some', 'active', 'activated', 'include', 'included',
+        't', 'true', 'yes', 'ok', 'on', '1', '+', 'v', 'x', 'some', 'active', 'activated', 'include', 'included',
         'enable', 'enabled', 'allow', 'allowed', 'set', 'ready', 'process', 'processed', 'add', 'added',
         'run', 'running', 'go', 'start', 'able', 'capable', 'possible', 'can', 'permit', 'permitted', 'show',
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
         'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
-        'affirmative', 'happy', 'positive'
+        'affirmative', 'happy', 'positive', 'select', 'selected'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -157,7 +157,8 @@ def boolean(bool_string: Union[str, bool]) -> bool:
         'create', 'created', 'awake', 'wake', 'wakeup', 'wake-up', 'wake up', 'power', 'power-up', 'powerup',
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
         'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
-        'affirmative', 'happy', 'positive', 'select', 'selected'
+        'affirmative', 'happy', 'positive', 'select', 'selected', 'matter', 'important', 'done', 'load', 'loaded',
+        'do', 'perform'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from typing import Any
+from typing import Tuple
 from collections import deque
 import datetime
 import re
@@ -35,6 +36,13 @@ import dateparser
 #     license: https://github.com/scrapinghub/dateparser/blob/master/LICENSE
 
 
+def time_range(time_string: str) -> Tuple[datetime.datetime, datetime.datetime]:
+    assigned_range = re.match(r'^.*?between\s(.*?)\sand\s(.*?$)', time_string, flags=re.IGNORECASE)
+    if assigned_range:
+        from_time_string, to_time_string = assigned_range.groups()
+        return dateparser.parse(from_time_string), dateparser.parse(to_time_string)
+
+
 def time(time_string: str) -> datetime.datetime:
     """
     Parse a time string into a datetime object.
@@ -55,16 +63,22 @@ def time(time_string: str) -> datetime.datetime:
         Results in a `datetime` object set to 1 day before
          the current time of execution.
 
+    A random datetime can also be acquired using `between` and `and` words:
+        "between 3 days ago and 2 days ago"
+        "between yesterday and today"
+        "between yesterday and now"
+        "between 1/1/2020 and 31/12/2023"
+
 
     :param time_string:
     :return: datetime object
     """
-    assigned_range = re.match(r'^.*?between\s(.*?)\sand\s(.*?$)', time_string, flags=re.IGNORECASE)
-    if assigned_range:
-        from_time_string, to_time_string = assigned_range.groups()
+    datetime_range = time_range(time_string)
+    if datetime_range:
+        from_time_string, to_time_string = datetime_range
         result = random.time(
-            dateparser.parse(from_time_string),
-            dateparser.parse(to_time_string)
+            from_time_string,
+            to_time_string
         )
     else:
         result = dateparser.parse(time_string)
@@ -88,6 +102,7 @@ def timedelta(time_delta_string: str) -> datetime.timedelta:
 
         A random timedelta can also be acquired using `from` and `to` words:
             "from every 1 second to 2 minutes"
+            "from 5 minutes to 1 hour"
 
         This will produce a random timedelta between `1 second` to `2 minutes`.
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -158,7 +158,7 @@ def boolean(bool_string: Union[str, bool]) -> bool:
         'power up', 'alive', 'live', 'lives', 'contain', 'contained', 'insert', 'inserted', 'assign', 'assigned',
         'import', 'imported', 'extract', 'extracted', 'promote', 'promoted', 'acknowledge', 'acknowledged',
         'affirmative', 'happy', 'positive', 'select', 'selected', 'matter', 'important', 'done', 'load', 'loaded',
-        'do', 'perform'
+        'do', 'perform', 'save', 'saved', 'load', 'loaded', 'reload'
     }
 
 

--- a/siemkit/parse.py
+++ b/siemkit/parse.py
@@ -146,7 +146,7 @@ def size(size_string: str) -> int:
 def boolean(bool_string: str) -> bool:
 
     bool_string = bool_string.strip().lower()
-    return bool_string in ('t', 'true', 'yes', 'ok', 'on', '1', 'some')
+    return bool_string in ('t', 'true', 'yes', 'ok', 'on', '1', 'some', 'active', 'activated')
 
 
 def variable(var_string: str, var_dict: dict) -> Any:

--- a/siemkit/random.py
+++ b/siemkit/random.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from random import randint
+from random import uniform
 from random import getrandbits
 from random import choice
 
@@ -25,6 +26,8 @@ import os
 import threading
 from time import time
 from math import floor
+from datetime import datetime
+from datetime import timedelta
 
 from .const import DOMAINS
 from .const import NAMES
@@ -244,3 +247,30 @@ def http_redirection_code() -> int:
 def http_server_error_code() -> int:
     return next(compose_http_server_error_code())
 
+
+def time(start_time: datetime = None, end_time: datetime = None, gap: timedelta = None) -> datetime:
+
+    if end_time is None and isinstance(start_time, datetime) and isinstance(gap, timedelta):
+        # Gap forward in time
+        end_time = start_time + gap
+
+    elif start_time is None and isinstance(end_time, datetime) and isinstance(gap, timedelta):
+        # Gap back in time
+        start_time = end_time - gap
+
+    elif start_time is None and end_time is None:
+
+        # Default
+
+        end_time = datetime.now()
+
+        if gap is None:
+            start_time = end_time - timedelta(minutes=1)
+        else:
+            start_time = end_time - gap
+
+    return datetime.fromtimestamp(
+        uniform(
+            start_time.timestamp(), end_time.timestamp()
+        )
+    )

--- a/siemkit/random.py
+++ b/siemkit/random.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+
 from random import randint
 from random import uniform
 from random import getrandbits
@@ -167,6 +168,54 @@ def generate_port(from_port: int = 0, to_port: int = 65535, amount: int = 1) -> 
         yield randint(from_port, to_port)
 
 
+def generate_timedelta(
+        start_timedelta: datetime_timedelta,
+        end_timedelta: datetime_timedelta,
+        amount: int = 1
+) -> Generator[datetime_timedelta, None, None]:
+    for _ in range(amount):
+        yield datetime_timedelta(
+            seconds=uniform(
+                start_timedelta.total_seconds(),
+                end_timedelta.total_seconds()
+            )
+        )
+
+
+def generate_time(
+        start_time: datetime = None,
+        end_time: datetime = None,
+        gap: datetime_timedelta = None,
+        amount: int = 1
+) -> Generator[datetime, None, None]:
+
+    if end_time is None and isinstance(start_time, datetime) and isinstance(gap, datetime_timedelta):
+        # Gap forward in time
+        end_time = start_time + gap
+
+    elif start_time is None and isinstance(end_time, datetime) and isinstance(gap, datetime_timedelta):
+        # Gap back in time
+        start_time = end_time - gap
+
+    elif start_time is None and end_time is None:
+
+        # Default
+
+        end_time = datetime.now()
+
+        if gap is None:
+            start_time = end_time - datetime_timedelta(minutes=1)
+        else:
+            start_time = end_time - gap
+
+    for _ in range(amount):
+        yield datetime.fromtimestamp(
+            uniform(
+                start_time.timestamp(), end_time.timestamp()
+            )
+        )
+
+
 def enum_value(*enums: EnumMeta) -> object:
     return next(generate_enum_value(*enums, amount=1))
 
@@ -249,40 +298,10 @@ def http_server_error_code() -> int:
 
 
 def time(start_time: datetime = None, end_time: datetime = None, gap: datetime_timedelta = None) -> datetime:
-
-    if end_time is None and isinstance(start_time, datetime) and isinstance(gap, datetime_timedelta):
-        # Gap forward in time
-        end_time = start_time + gap
-
-    elif start_time is None and isinstance(end_time, datetime) and isinstance(gap, datetime_timedelta):
-        # Gap back in time
-        start_time = end_time - gap
-
-    elif start_time is None and end_time is None:
-
-        # Default
-
-        end_time = datetime.now()
-
-        if gap is None:
-            start_time = end_time - datetime_timedelta(minutes=1)
-        else:
-            start_time = end_time - gap
-
-    return datetime.fromtimestamp(
-        uniform(
-            start_time.timestamp(), end_time.timestamp()
-        )
-    )
+    return next(generate_time(start_time, end_time, gap))
 
 
 def timedelta(start_timedelta: datetime_timedelta, end_timedelta: datetime_timedelta) -> datetime_timedelta:
-
-    return datetime_timedelta(
-        seconds=uniform(
-            start_timedelta.total_seconds(),
-            end_timedelta.total_seconds()
-        )
-    )
+    return next(generate_timedelta(start_timedelta, end_timedelta))
 
 

--- a/siemkit/random.py
+++ b/siemkit/random.py
@@ -392,5 +392,3 @@ def time(start_time: datetime = None, end_time: datetime = None, gap: datetime_t
 
 def timedelta(start_timedelta: datetime_timedelta, end_timedelta: datetime_timedelta) -> datetime_timedelta:
     return next(generate_timedelta(start_timedelta, end_timedelta))
-
-

--- a/siemkit/random.py
+++ b/siemkit/random.py
@@ -55,7 +55,10 @@ def generate_ip(
         to_address: Union[IPv4Address, str] = '255.255.255.255',
         amount: int = 1) -> Generator[IPv4Address, None, None]:
 
-    for _ in range(amount):
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
 
         yield IPv4Address(
             randint(
@@ -66,13 +69,22 @@ def generate_ip(
 
 
 def generate_domain(amount: int = 1) -> Generator[str, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield choice(DOMAINS)
 
 
 def generate_url(amount: int = 1) -> Generator[str, None, None]:
 
-    for _ in range(amount):
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield (f"{enum_value(web.Protocol)}://{choice(DOMAINS)}/"
                f"{choice(NAMES).lower()}/{randint(0, 1000)}/"
                f"{choice(NAMES).lower()}?{choice(NAMES).lower()}={randint(0, 1000)}"
@@ -80,32 +92,62 @@ def generate_url(amount: int = 1) -> Generator[str, None, None]:
 
 
 def generate_email(amount: int = 1) -> Generator[str, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield f"{choice(NAMES).lower()}{randint(10, 80)}@{choice(DOMAINS)}"
 
 
 def generate_user(amount: int = 1) -> Generator[str, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield f"{choice(NAMES)}{choice(NAMES)}{randint(10, 80)}"
 
 
 def generate_md5(amount: int = 1) -> Generator[str, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield hex(getrandbits(128))[2:]
 
 
 def generate_sha1(amount: int = 1) -> Generator[str, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield hex(getrandbits(160))[2:]
 
 
 def generate_enum_value(*enums: EnumMeta, amount: int = 1) -> Generator[object, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield choice(tuple(choice(enums))).value
 
 
 def generate_http_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(
             web.HttpInformationalCode,
             web.HttpSuccessCode,
@@ -116,22 +158,42 @@ def generate_http_code(amount: int = 1) -> Generator[int, None, None]:
 
 
 def generate_http_information_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(web.HttpInformationalCode)
 
 
 def generate_http_success_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(web.HttpSuccessCode)
 
 
 def generate_http_redirection_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(web.HttpRedirectionCode)
 
 
 def generate_http_error_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(
             web.HttpClientErrorCode,
             web.HttpServerErrorCode
@@ -139,17 +201,31 @@ def generate_http_error_code(amount: int = 1) -> Generator[int, None, None]:
 
 
 def generate_http_client_error_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(web.HttpClientErrorCode)
 
 
 def generate_http_server_error_code(amount: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield enum_value(web.HttpServerErrorCode)
 
 
 def generate_flag_value(*enums: EnumMeta, amount: int = 1, flags: int = 1) -> Generator[int, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
 
         random_flag = 0
 
@@ -164,7 +240,11 @@ def generate_port(from_port: int = 0, to_port: int = 65535, amount: int = 1) -> 
     if not (0 <= from_port <= to_port <= 65535):
         raise ValueError("Illegal port range. Legal port range 0-65535.")
 
-    for _ in range(amount):
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield randint(from_port, to_port)
 
 
@@ -173,7 +253,12 @@ def generate_timedelta(
         end_timedelta: datetime_timedelta,
         amount: int = 1
 ) -> Generator[datetime_timedelta, None, None]:
-    for _ in range(amount):
+
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield datetime_timedelta(
             seconds=uniform(
                 start_timedelta.total_seconds(),
@@ -208,7 +293,11 @@ def generate_time(
         else:
             start_time = end_time - gap
 
-    for _ in range(amount):
+    for current_count in range(amount):
+
+        if current_count == amount:
+            break
+
         yield datetime.fromtimestamp(
             uniform(
                 start_time.timestamp(), end_time.timestamp()

--- a/siemkit/random.py
+++ b/siemkit/random.py
@@ -49,7 +49,7 @@ def byte() -> int:
     return randint(0, 255)
 
 
-def compose_ip(
+def generate_ip(
         from_address: Union[IPv4Address, str] = '0.0.0.0',
         to_address: Union[IPv4Address, str] = '255.255.255.255',
         amount: int = 1) -> Generator[IPv4Address, None, None]:
@@ -64,12 +64,12 @@ def compose_ip(
         )
 
 
-def compose_domain(amount: int = 1) -> Generator[str, None, None]:
+def generate_domain(amount: int = 1) -> Generator[str, None, None]:
     for _ in range(amount):
         yield choice(DOMAINS)
 
 
-def compose_url(amount: int = 1) -> Generator[str, None, None]:
+def generate_url(amount: int = 1) -> Generator[str, None, None]:
 
     for _ in range(amount):
         yield (f"{enum_value(web.Protocol)}://{choice(DOMAINS)}/"
@@ -78,32 +78,32 @@ def compose_url(amount: int = 1) -> Generator[str, None, None]:
                f"&{choice(NAMES).lower()}={randint(0, 1000)}")
 
 
-def compose_email(amount: int = 1) -> Generator[str, None, None]:
+def generate_email(amount: int = 1) -> Generator[str, None, None]:
     for _ in range(amount):
         yield f"{choice(NAMES).lower()}{randint(10, 80)}@{choice(DOMAINS)}"
 
 
-def compose_user(amount: int = 1) -> Generator[str, None, None]:
+def generate_user(amount: int = 1) -> Generator[str, None, None]:
     for _ in range(amount):
         yield f"{choice(NAMES)}{choice(NAMES)}{randint(10, 80)}"
 
 
-def compose_md5(amount: int = 1) -> Generator[str, None, None]:
+def generate_md5(amount: int = 1) -> Generator[str, None, None]:
     for _ in range(amount):
         yield hex(getrandbits(128))[2:]
 
 
-def compose_sha1(amount: int = 1) -> Generator[str, None, None]:
+def generate_sha1(amount: int = 1) -> Generator[str, None, None]:
     for _ in range(amount):
         yield hex(getrandbits(160))[2:]
 
 
-def compose_enum_value(*enums: EnumMeta, amount: int = 1) -> Generator[object, None, None]:
+def generate_enum_value(*enums: EnumMeta, amount: int = 1) -> Generator[object, None, None]:
     for _ in range(amount):
         yield choice(tuple(choice(enums))).value
 
 
-def compose_http_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(
             web.HttpInformationalCode,
@@ -114,22 +114,22 @@ def compose_http_code(amount: int = 1) -> Generator[int, None, None]:
         )
 
 
-def compose_http_information_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_information_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(web.HttpInformationalCode)
 
 
-def compose_http_success_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_success_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(web.HttpSuccessCode)
 
 
-def compose_http_redirection_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_redirection_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(web.HttpRedirectionCode)
 
 
-def compose_http_error_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_error_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(
             web.HttpClientErrorCode,
@@ -137,17 +137,17 @@ def compose_http_error_code(amount: int = 1) -> Generator[int, None, None]:
         )
 
 
-def compose_http_client_error_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_client_error_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(web.HttpClientErrorCode)
 
 
-def compose_http_server_error_code(amount: int = 1) -> Generator[int, None, None]:
+def generate_http_server_error_code(amount: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
         yield enum_value(web.HttpServerErrorCode)
 
 
-def compose_flag_value(*enums: EnumMeta, amount: int = 1, flags: int = 1) -> Generator[int, None, None]:
+def generate_flag_value(*enums: EnumMeta, amount: int = 1, flags: int = 1) -> Generator[int, None, None]:
     for _ in range(amount):
 
         random_flag = 0
@@ -158,7 +158,7 @@ def compose_flag_value(*enums: EnumMeta, amount: int = 1, flags: int = 1) -> Gen
         yield random_flag
 
 
-def compose_port(from_port: int = 0, to_port: int = 65535, amount: int = 1) -> Generator[int, None, None]:
+def generate_port(from_port: int = 0, to_port: int = 65535, amount: int = 1) -> Generator[int, None, None]:
 
     if not (0 <= from_port <= to_port <= 65535):
         raise ValueError("Illegal port range. Legal port range 0-65535.")
@@ -168,18 +168,18 @@ def compose_port(from_port: int = 0, to_port: int = 65535, amount: int = 1) -> G
 
 
 def enum_value(*enums: EnumMeta) -> object:
-    return next(compose_enum_value(*enums, amount=1))
+    return next(generate_enum_value(*enums, amount=1))
 
 
 def flag_value(*enums: EnumMeta, flags=1) -> int:
-    return next(compose_flag_value(*enums, flags=flags))
+    return next(generate_flag_value(*enums, flags=flags))
 
 
 def ip(from_address: Union[IPv4Address, str] = '0.0.0.0',
        to_address: Union[IPv4Address, str] = '255.255.255.255') -> IPv4Address:
 
     return next(
-        compose_ip(
+        generate_ip(
             from_address=from_address,
             to_address=to_address
         )
@@ -189,7 +189,7 @@ def ip(from_address: Union[IPv4Address, str] = '0.0.0.0',
 def port(from_port: int = 0, to_port: int = 65535) -> int:
 
     return next(
-        compose_port(
+        generate_port(
             from_port=from_port,
             to_port=to_port
         )
@@ -197,55 +197,55 @@ def port(from_port: int = 0, to_port: int = 65535) -> int:
 
 
 def md5() -> str:
-    return next(compose_md5())
+    return next(generate_md5())
 
 
 def sha1() -> str:
-    return next(compose_sha1())
+    return next(generate_sha1())
 
 
 def email() -> str:
-    return next(compose_email())
+    return next(generate_email())
 
 
 def url() -> str:
-    return next(compose_url())
+    return next(generate_url())
 
 
 def user() -> str:
-    return next(compose_user())
+    return next(generate_user())
 
 
 def domain() -> str:
-    return next(compose_domain())
+    return next(generate_domain())
 
 
 def http_code() -> int:
-    return next(compose_http_code())
+    return next(generate_http_code())
 
 
 def http_information_code() -> int:
-    return next(compose_http_information_code())
+    return next(generate_http_information_code())
 
 
 def http_success_code() -> int:
-    return next(compose_http_success_code())
+    return next(generate_http_success_code())
 
 
 def http_error_code() -> int:
-    return next(compose_http_error_code())
+    return next(generate_http_error_code())
 
 
 def http_client_error_code() -> int:
-    return next(compose_http_client_error_code())
+    return next(generate_http_client_error_code())
 
 
 def http_redirection_code() -> int:
-    return next(compose_http_redirection_code())
+    return next(generate_http_redirection_code())
 
 
 def http_server_error_code() -> int:
-    return next(compose_http_server_error_code())
+    return next(generate_http_server_error_code())
 
 
 def time(start_time: datetime = None, end_time: datetime = None, gap: datetime_timedelta = None) -> datetime:

--- a/siemkit/random.py
+++ b/siemkit/random.py
@@ -27,7 +27,7 @@ import threading
 from time import time
 from math import floor
 from datetime import datetime
-from datetime import timedelta
+from datetime import timedelta as datetime_timedelta
 
 from .const import DOMAINS
 from .const import NAMES
@@ -248,13 +248,13 @@ def http_server_error_code() -> int:
     return next(compose_http_server_error_code())
 
 
-def time(start_time: datetime = None, end_time: datetime = None, gap: timedelta = None) -> datetime:
+def time(start_time: datetime = None, end_time: datetime = None, gap: datetime_timedelta = None) -> datetime:
 
-    if end_time is None and isinstance(start_time, datetime) and isinstance(gap, timedelta):
+    if end_time is None and isinstance(start_time, datetime) and isinstance(gap, datetime_timedelta):
         # Gap forward in time
         end_time = start_time + gap
 
-    elif start_time is None and isinstance(end_time, datetime) and isinstance(gap, timedelta):
+    elif start_time is None and isinstance(end_time, datetime) and isinstance(gap, datetime_timedelta):
         # Gap back in time
         start_time = end_time - gap
 
@@ -265,7 +265,7 @@ def time(start_time: datetime = None, end_time: datetime = None, gap: timedelta 
         end_time = datetime.now()
 
         if gap is None:
-            start_time = end_time - timedelta(minutes=1)
+            start_time = end_time - datetime_timedelta(minutes=1)
         else:
             start_time = end_time - gap
 
@@ -274,3 +274,15 @@ def time(start_time: datetime = None, end_time: datetime = None, gap: timedelta 
             start_time.timestamp(), end_time.timestamp()
         )
     )
+
+
+def timedelta(start_timedelta: datetime_timedelta, end_timedelta: datetime_timedelta) -> datetime_timedelta:
+
+    return datetime_timedelta(
+        seconds=uniform(
+            start_timedelta.total_seconds(),
+            end_timedelta.total_seconds()
+        )
+    )
+
+

--- a/siemkit/send.py
+++ b/siemkit/send.py
@@ -83,7 +83,9 @@ def tcp(host: str, port: int, payload: Any, repeat: int = 1, timeout: int = 3) -
 
         for iteration in range(repeat):
             for unpacked_item in unpack(payload):
-                sent_bytes += session.write(to_bytes(unpacked_item))
+                bytes_payload = to_bytes(unpacked_item)
+                session.write(bytes_payload)
+                sent_bytes += len(bytes_payload)
 
     return sent_bytes
 

--- a/siemkit/simulate/__init__.py
+++ b/siemkit/simulate/__init__.py
@@ -11,3 +11,5 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from . import cef

--- a/siemkit/simulate/cef/__init__.py
+++ b/siemkit/simulate/cef/__init__.py
@@ -120,6 +120,7 @@ def process_random_value(value_):
         return value_
 
 
+# ToDo: Remember last time of event generation and use as `start_time` where now is `end_time`, for `random.time`
 def random_event(event=None, amount=1,  **fields):
 
     if event is None:

--- a/siemkit/simulate/cef/__init__.py
+++ b/siemkit/simulate/cef/__init__.py
@@ -65,7 +65,7 @@ def fake_ip_scan(event: Cef = None) -> Generator[Cef, None, None]:
         1. Pick a random attacker IP address between 172.16.0.1 - 172.16.0.254
         2. Scan addresses 192.168.0.1 - 192.168.0.10
         3. Pick a random victim IP address between 192.168.0.1 - 192.168.0.10
-        4. Wait 10 seconds
+        4. Wait a random time from 10 to 25 seconds
         5. Successful Telnet connection to the random victim address (3)
 
     :param event: Optional CEF event to work with. The CEF original state is kept protected.

--- a/siemkit/simulate/cef/__init__.py
+++ b/siemkit/simulate/cef/__init__.py
@@ -12,13 +12,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from collections.abc import Sequence
 from typing import Generator
+from types import GeneratorType
 
 from siemkit.event import Cef
 from siemkit.time import sleep
 from siemkit import random
 from siemkit import generate
 from random import randint
+from random import choice
 
 
 def random_number(start_range: int = None, end_range: int = None, amount: int = 1, event: Cef = None) \
@@ -96,3 +99,29 @@ def fake_ip_scan(event: Cef = None) -> Generator[Cef, None, None]:
             yield event
 
     print("Done simulating.")
+
+
+def random_event(event=None, amount=1,  **fields):
+
+    def random_value(value_):
+
+        if isinstance(value_, GeneratorType):
+            return random_value(next(value_))
+        elif callable(value_):
+            return random_value(value_())
+        elif not isinstance(value_, (dict, str)) and isinstance(value_, Sequence):
+            return choice(value_)
+        else:
+            return value_
+
+    if event is None:
+        event = Cef()
+
+    for _ in range(amount):
+
+        with event:
+
+            for key, value in fields.items():
+                event[key] = random_value(value)
+
+            yield event

--- a/siemkit/simulate/cef/__init__.py
+++ b/siemkit/simulate/cef/__init__.py
@@ -15,13 +15,14 @@
 from collections.abc import Sequence
 from typing import Generator
 from types import GeneratorType
+from random import randint
+from random import choice
 
 from siemkit.event import Cef
 from siemkit.time import sleep
 from siemkit import random
 from siemkit import generate
-from random import randint
-from random import choice
+from siemkit import parse
 
 
 def random_number(start_range: int = None, end_range: int = None, amount: int = 1, event: Cef = None) \
@@ -89,7 +90,7 @@ def fake_ip_scan(event: Cef = None) -> Generator[Cef, None, None]:
                 event.destinationAddress = fake_scan_addresses.pop()
                 yield event
 
-        sleep(seconds=10)
+        sleep(parse.timedelta("from 10 seconds to 25 seconds"))
 
         print("Simulating fake successful Telnet connection . . .")
         with event:

--- a/siemkit/time.py
+++ b/siemkit/time.py
@@ -166,10 +166,10 @@ class LdapTimestamp(Timestamp):
         zulu_time_zone = '.0Z'
 
         return (
-                datetime_
-                    .replace(tzinfo=tz)
-                    .astimezone(tz=timezone.utc)
-                    .strftime("%Y%m%d%H%M%S") + zulu_time_zone
+            datetime_
+                .replace(tzinfo=tz)
+                .astimezone(tz=timezone.utc)
+                .strftime("%Y%m%d%H%M%S") + zulu_time_zone
         )
 
     @classmethod


### PR DESCRIPTION
## Version 0.0.17-dev
* Added a random time generation `siemkit.random.time`
* Added a random time delta generation `siemkit.random.timedelta`
* Added a random time delta support for timedelta parsing `siemkit.parse.timedelta`
    - Examples of supported strings:
        - `from 1 day to 2 days`
        - `from 5 minutes to 1 hour`
        - `from every 2 minutes and 30 seconds to 5 minutes` 
* Added a random time support for time parsing `siemkit.parse.time`
    - Examples of supported strings:
        - `between yesterday and today`
        - `between yesterday and now`
        - `between 2 days ago and now`
        - `between 3 days ago and 2 days ago`
        - `between 1/1/2020 and 31/12/2023`
* Added parsing support for time range: `siemkit.parse.time_range` will produce a tuple of start and end time
* Re-imported sub-libraries for multi-layered APIs
* All generators under `siemkit.random` were refactored from `compose` to `generate`
* Added ArcSight ESM API Manager methods:
    - `Esm.get_activelist_fields()`
    - `Esm.get_activelist_columns()`
    - `Esm.add_activelist_entries()`
* Passing columns to `remove_activelist_entries()` & `add_activelist_entries()` is only optional
    - Not providing the `_columns_order` field for an entry, will cause the API to automatically make a `get_activelist_columns()` call
* Improved ArcSight ESM API `retrieve_event_ids()` generator to be able to filter event types and retrieve recursively
* Fixed `siemkit.send.tcp` function
* Added `siemkit.event.Cef` aliases for `severity` & `deviceSeverity` are now both acceptable
* Changed: `siemkit.parse.boolean` is now using a `set` type for value testing instead of a `tuple`
    - Also supports `bool` value type as argument
* Created a `default` settings dictionary for the `siemkit.parse` library
    - Included: `parse_true` key holding a set of words to parse as `True`
* Added `siemkit.parse.boolean` (based on `default['parse_true']`) new valid values for `True`:
    - `active`
    - `activated`
    - `include`
    - `included`
    - `enable`
    - `enabled`
    - `set`
    - `ready`
    - `allow`
    - `allowed`
    - `process`
    - `processed`
    - `add`
    - `added`
    - `run`
    - `running`
    - `go`
    - `start`
    - `able`
    - `capable`
    - `possible`
    - `can`
    - `permit`
    - `permitted`
    - `show`
    - `create`
    - `created`
    - `awake`
    - `wake`
    - `wakeup`
    - `wake-up`
    - `wake up`
    - `power`
    - `power-up`
    - `powerup`
    - `power up`
    - `alive`
    - `live`
    - `lives`
    - `contain`
    - `contained`
    - `insert`
    - `inserted`
    - `assign`
    - `assigned`
    - `import`
    - `imported`
    - `extract`
    - `extracted`
    - `+`
    - `v`
    - `x`
    - `k`
    - `y`
    - `promote`
    - `promoted`
    - `acknowledge`
    - `acknowledged`
    - `affirmative`
    - `happy`
    - `positive`
    - `select`
    - `selected`
    - `matter`
    - `important`
    - `done`
    - `load`
    - `loaded`
    - `do`
    - `perform`
    - `save`
    - `saved`
    - `load`
    - `loaded`
    - `reload`
    - `get`
